### PR TITLE
 修复酷Q发送自定义图片和语音在CQ码中使用绝对路径的BUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+这是一个自用魔改版！
+
 # Newbe.Mahua.Framework
 
 先点击一下右上角的Star，开启隐藏功能。

--- a/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
+++ b/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
@@ -68,7 +68,10 @@ namespace Newbe.Mahua.CQP.Messages.Builders
             }
             _message.Append($"[CQ:image,file={fileName}]");
         }
-
+        /// <summary>
+        /// {1}为语音文件名称，图片存放在酷Q目录的data\record\下
+        /// </summary>
+        /// <param name="file"></param>
         public void Record(string file)
         {
             var fileName = Path.GetFileName(file);

--- a/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
+++ b/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
@@ -60,24 +60,24 @@ namespace Newbe.Mahua.CQP.Messages.Builders
         /// <param name="file"></param>
         public void Image(string file)
         {
-            var destFileName = file;
+            var fileName = Path.GetFileName(file);
             if (!file.StartsWith(CqpDirectories.Image))
             {
-                destFileName = Path.Combine(CqpDirectories.Image, Path.GetFileName(file));
-                File.Copy(file, destFileName);
+                var destFileName = Path.Combine(CqpDirectories.Image, fileName);
+                File.Copy(file, destFileName,true);
             }
-            _message.Append($"[CQ:image,file={destFileName}]");
+            _message.Append($"[CQ:image,file={fileName}]");
         }
 
         public void Record(string file)
         {
-            var destFileName = file;
-            if (!file.StartsWith(CqpDirectories.Record))
+            var fileName = Path.GetFileName(file);
+            if (!file.StartsWith(CqpDirectories.Image))
             {
-                destFileName = Path.Combine(CqpDirectories.Record, Path.GetFileName(file));
-                File.Copy(file, destFileName);
+                var destFileName = Path.Combine(CqpDirectories.Image, fileName);
+                File.Copy(file, destFileName, true);
             }
-            _message.Append($"[CQ:record,file={destFileName},magic=false]");
+            _message.Append($"[CQ:record,file={fileName},magic=false]");
         }
 
         public void SFace(string id)

--- a/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
+++ b/src/Newbe.Mahua.CQP/Messages/Builders/CqpMessageBuilder.cs
@@ -60,13 +60,13 @@ namespace Newbe.Mahua.CQP.Messages.Builders
         /// <param name="file"></param>
         public void Image(string file)
         {
-            var fileName = Path.GetFileName(file);
+            string newName = Guid.NewGuid().ToString() + "." + System.IO.Path.GetExtension(file);
             if (!file.StartsWith(CqpDirectories.Image))
             {
-                var destFileName = Path.Combine(CqpDirectories.Image, fileName);
+                var destFileName = Path.Combine(CqpDirectories.Image, newName);
                 File.Copy(file, destFileName,true);
             }
-            _message.Append($"[CQ:image,file={fileName}]");
+            _message.Append($"[CQ:image,file={newName}]");
         }
         /// <summary>
         /// {1}为语音文件名称，图片存放在酷Q目录的data\record\下
@@ -74,13 +74,13 @@ namespace Newbe.Mahua.CQP.Messages.Builders
         /// <param name="file"></param>
         public void Record(string file)
         {
-            var fileName = Path.GetFileName(file);
+            string newName = Guid.NewGuid().ToString() + "." + System.IO.Path.GetExtension(file);
             if (!file.StartsWith(CqpDirectories.Image))
             {
-                var destFileName = Path.Combine(CqpDirectories.Image, fileName);
+                var destFileName = Path.Combine(CqpDirectories.Image, newName);
                 File.Copy(file, destFileName, true);
             }
-            _message.Append($"[CQ:record,file={fileName},magic=false]");
+            _message.Append($"[CQ:record,file={newName},magic=false]");
         }
 
         public void SFace(string id)


### PR DESCRIPTION
1.修复酷Q发送自定义图片和语音在CQ码中使用绝对路径的BUG
2.将图片和语音文件名Copy为GUID避免重复（但是存在一个问题，同一张图片重复SEND的时候会产生很多文件名不同的相同图片，非常占空间）