### PR TITLE
fix build error when project path contains spaces

### DIFF
--- a/src/Newbe.Mahua.Plugins.Parrot/build.ps1
+++ b/src/Newbe.Mahua.Plugins.Parrot/build.ps1
@@ -52,7 +52,7 @@ Task Init -depends Clean -Description "初始化参数" {
 
 Task Nuget -depends Init -Description "nuget restore" {
     Exec {
-        cmd /c ""$nugetexe" restore  -PackagesDirectory $rootNow\..\packages"
+        cmd /c """$nugetexe"" restore  -PackagesDirectory ""$rootNow\..\packages"""
     }
 }
 


### PR DESCRIPTION
How to reproduce:

1. Create a new project using `Newbe.Mahua.Plugins.Template`
2. Save it in a path contains space(s), like  `C:\Users\[UserName]\Documents\Visual Studio 2017\Projects\[ProjectName]`
3. Write something, build project, run build.bat

Then you should see error showed below
![image](https://user-images.githubusercontent.com/7760499/39506292-2a5463f4-4e0a-11e8-8cbc-b92afc9733a9.png)