### PR TITLE
修复CleverQQ发送图片失败的问题

### DIFF
--- a/src/Newbe.Mahua.CleverQQ/Messages/Builders/CleverQQMessageBuilder.cs
+++ b/src/Newbe.Mahua.CleverQQ/Messages/Builders/CleverQQMessageBuilder.cs
@@ -84,12 +84,12 @@ namespace Newbe.Mahua.CleverQQ.Messages.Builders
         }
 
         /// <summary>
-        /// {1}为图片文件名称，图片存放在酷Q目录的data\image\下
+        /// 发送图片
         /// </summary>
-        /// <param name="file"></param>
+        /// <param name="file">为已存在的{GUID}(不可缺少大括号),或网络图片地址、本地有权读取的图片文件</param>
         public void Image(string file)
         {
-            var id = _cleverqqMessage.Images.Add(file);
+            var id = $"[IR:pic={file}]";
             _cleverqqMessage.Append(id);
         }
 

--- a/src/Newbe.Mahua.CleverQQ/Messages/CleverQQMessage.cs
+++ b/src/Newbe.Mahua.CleverQQ/Messages/CleverQQMessage.cs
@@ -18,6 +18,5 @@ namespace Newbe.Mahua.CleverQQ.Messages
         }
 
         public bool Shake { get; set; }
-        public ImageCollection Images { get; } = new ImageCollection();
     }
 }

--- a/src/Newbe.Mahua.CleverQQ/Messages/ICleverQQMessage.cs
+++ b/src/Newbe.Mahua.CleverQQ/Messages/ICleverQQMessage.cs
@@ -10,54 +10,6 @@ namespace Newbe.Mahua.CleverQQ.Messages
     {
         bool Shake { get; set; }
 
-        ImageCollection Images { get; }
     }
-
-    public class ImageCollection : IEnumerable<KeyValuePair<string, string>>
-    {
-        private IDictionary<string, string> _images = new Dictionary<string, string>();
-
-        public string Add(string file)
-        {
-            var id = GetId(_images.Count);
-            _images.Add(id, file);
-            return id;
-        }
-        public void Upload(Func<string, string> uploader)
-        {
-            var currentDic = AppDomain.CurrentDomain.BaseDirectory;
-            _images = _images.ToDictionary(x => x.Key,
-                image =>
-                {
-                    var file = image.Value;
-                    if (file.StartsWith("http") || file.StartsWith(currentDic))
-                    {
-                        return $"[{image.Value}]";
-                    }
-                    var re = uploader(file);
-                    return re;
-                });
-        }
-
-        public string Formate(string source)
-        {
-            var re = source;
-            foreach (var image in _images)
-            {
-                re = re.Replace(image.Key, image.Value);
-            }
-            return re;
-        }
-
-        private string GetId(int index) => $"[cleverqqImage_{index}]";
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
-        {
-            return _images.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
     }
 }


### PR DESCRIPTION
#49 #50 
这次是真的修复了。
删除ImageCollection-IRQQ底层会检测并解析IR图片码，并进行相应图片的读取和上传，不需要Mahua进行上传。